### PR TITLE
Fix DB alias for conn variable

### DIFF
--- a/db.php
+++ b/db.php
@@ -15,6 +15,9 @@ $options = [
 
 try {
     $pdo = new PDO($dsn, $user, $pass, $options);
+    // Uyumlu olması için $conn değişkeni de aynı nesneye işaret etsin
+    // Bazı sayfalarda PDO bağlantısı $conn adıyla kullanılıyor
+    $conn = $pdo;
 } catch (\PDOException $e) {
     throw new \PDOException($e->getMessage(), (int)$e->getCode());
 }


### PR DESCRIPTION
## Summary
- assign `$conn` to reference `$pdo` in `db.php`

## Testing
- `php -l` on all PHP files
- `composer install`

------
https://chatgpt.com/codex/tasks/task_e_687be8690a9c8330bd651c92a34b697d