### PR TITLE
Add Bootstrap DataTables and shared layout

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,13 @@
+</div>
+<script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.4/js/dataTables.bootstrap5.min.js"></script>
+<script>
+$(function(){
+    $('.datatable').DataTable();
+});
+</script>
+</body>
+</html>
+

--- a/header.php
+++ b/header.php
@@ -1,0 +1,12 @@
+<?php if (!isset($title)) { $title = 'Teklif Yönetimi'; } ?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <title><?= htmlspecialchars($title) ?></title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container-fluid">
+

--- a/index.php
+++ b/index.php
@@ -1,57 +1,26 @@
-<?php include 'db.php'; ?>
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8">
-  <title>Teklif Yönetimi</title>
-  <style>
-    body {
-      margin: 0;
-      font-family: Arial, sans-serif;
-    }
-    .sidebar {
-      width: 200px;
-      height: 100vh;
-      background-color: #f5f5f5;
-      padding-top: 20px;
-      position: fixed;
-    }
-    .sidebar a {
-      display: block;
-      padding: 10px 20px;
-      color: #333;
-      text-decoration: none;
-    }
-    .sidebar a:hover {
-      background-color: #ddd;
-    }
-    .content {
-      margin-left: 200px;
-      padding: 20px;
-    }
-  </style>
-</head>
-<body>
-  <div class="sidebar">
-    <a href="?page=kapsamlar">Kapsamlar</a>
-    <a href="?page=kategoriler">Kategoriler</a>
-    <a href="?page=is_kalemleri">İş Kalemleri</a>
-  </div>
-
-  <div class="content">
-    <?php
-    if (isset($_GET['page'])) {
-      $page = $_GET['page'];
-      $allowed = ['kapsamlar', 'kategoriler', 'is_kalemleri', 'kapsam_olustur']; // güvenlik için filtreleme
-      if (in_array($page, $allowed)) {
-        include $page . '.php';
-      } else {
-        echo "<p>Geçersiz sayfa.</p>";
-      }
-    } else {
-      include 'kapsamlar.php'; // varsayılan sayfa
-    }
-    ?>
-  </div>
-</body>
-</html>
+<?php
+include 'db.php';
+$title = 'Teklif Yönetimi';
+include 'header.php';
+?>
+<div class="row">
+    <div class="col-md-2 bg-light min-vh-100">
+        <?php include 'sidebar.php'; ?>
+    </div>
+    <div class="col-md-10 pt-3">
+        <?php
+        if (isset($_GET['page'])) {
+            $page = $_GET['page'];
+            $allowed = ['kapsamlar', 'kategoriler', 'is_kalemleri', 'kapsam_olustur'];
+            if (in_array($page, $allowed)) {
+                include $page . '.php';
+            } else {
+                echo '<p>Geçersiz sayfa.</p>';
+            }
+        } else {
+            include 'kapsamlar.php';
+        }
+        ?>
+    </div>
+</div>
+<?php include 'footer.php'; ?>

--- a/is_kalemleri.php
+++ b/is_kalemleri.php
@@ -1,36 +1,57 @@
 <?php
-// is_kalemleri.php - tek dosyada iş kalemi listeleme, ekleme, silme işlemleri
-include "db.php";
-if ($_SERVER["REQUEST_METHOD"] === "POST") {
-    if (isset($_POST["baslik"])) {
-        $stmt = $pdo->prepare("INSERT INTO items (category_id, name, description) VALUES (?, ?, ?)");
-        $stmt->execute([$_POST["kategori_id"], $_POST["baslik"], $_POST["aciklama"]]);
+// is_kalemleri.php - iş kalemi listeleme, ekleme, silme
+include 'db.php';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['baslik'])) {
+        $stmt = $pdo->prepare('INSERT INTO items (category_id, name, description) VALUES (?, ?, ?)');
+        $stmt->execute([$_POST['kategori_id'], $_POST['baslik'], $_POST['aciklama']]);
     }
-    if (isset($_POST["sil_id"])) {
-        $stmt = $pdo->prepare("DELETE FROM items WHERE id = ?");
-        $stmt->execute([$_POST["sil_id"]]);
+    if (isset($_POST['sil_id'])) {
+        $stmt = $pdo->prepare('DELETE FROM items WHERE id = ?');
+        $stmt->execute([$_POST['sil_id']]);
     }
 }
-$is_kalemleri = $pdo->query("SELECT i.*, c.name AS kategori_adi FROM items i JOIN categories c ON i.category_id = c.id")->fetchAll();
+$is_kalemleri = $pdo->query('SELECT i.*, c.name AS kategori_adi FROM items i JOIN categories c ON i.category_id = c.id')->fetchAll();
+$kategoriler = $pdo->query('SELECT id, name FROM categories')->fetchAll();
 ?>
-<!DOCTYPE html>
-<html>
-<head><title>İş Kalemleri</title></head>
-<body>
 <h2>İş Kalemleri Listesi</h2>
-<ul>
-<?php foreach ($is_kalemleri as $kalem): ?>
-<li>[<?= $kalem['kategori_adi'] ?>] <?= htmlspecialchars($kalem['name']) ?> - <?= htmlspecialchars($kalem['description']) ?>
-<form method="post" style="display:inline;"><input type="hidden" name="sil_id" value="<?= $kalem['id'] ?>"><button>Sil</button></form>
-</li>
-<?php endforeach; ?>
-</ul>
+<table class="table datatable" id="is-kalemleri-table">
+    <thead>
+        <tr><th>Kategori</th><th>İş Kalemi</th><th>Açıklama</th><th>Sil</th></tr>
+    </thead>
+    <tbody>
+    <?php foreach ($is_kalemleri as $kalem): ?>
+        <tr>
+            <td><?= htmlspecialchars($kalem['kategori_adi']) ?></td>
+            <td><?= htmlspecialchars($kalem['name']) ?></td>
+            <td><?= htmlspecialchars($kalem['description']) ?></td>
+            <td>
+                <form method="post" onsubmit="return confirm('Silinsin mi?');" class="d-inline">
+                    <input type="hidden" name="sil_id" value="<?= $kalem['id'] ?>">
+                    <button class="btn btn-sm btn-danger">Sil</button>
+                </form>
+            </td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
 <h3>Yeni İş Kalemi Ekle</h3>
-<form method="post">
-Kategori ID: <input name="kategori_id"><br>
-Başlık: <input name="baslik"><br>
-Açıklama: <input name="aciklama"><br>
-<button>Ekle</button>
+<form method="post" class="row g-2 mb-3">
+    <div class="col-auto">
+        <select name="kategori_id" class="form-select" required>
+            <option value="">Kategori Seçin</option>
+            <?php foreach ($kategoriler as $kat): ?>
+                <option value="<?= $kat['id'] ?>"><?= htmlspecialchars($kat['name']) ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <div class="col-auto">
+        <input name="baslik" class="form-control" placeholder="Başlık" required>
+    </div>
+    <div class="col-auto">
+        <input name="aciklama" class="form-control" placeholder="Açıklama" required>
+    </div>
+    <div class="col-auto">
+        <button class="btn btn-primary">Ekle</button>
+    </div>
 </form>
-</body>
-</html>

--- a/kapsam_olustur.php
+++ b/kapsam_olustur.php
@@ -1,71 +1,67 @@
 <?php
 include 'db.php';
-include 'sidebar.php';
-
-if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    $scopeName = $_POST['scope_name'];
-    $includedItems = $_POST['included_items'] ?? [];
-    $descriptions = $_POST['descriptions'] ?? [];
-
-    try {
-        // Yeni kapsamı ekle
-        $stmt = $pdo->prepare("INSERT INTO scopes (name) VALUES (:name)");
-        $stmt->execute(['name' => $scopeName]);
-        $scopeId = $pdo->lastInsertId();
-
-        // Dahil edilen iş kalemlerini ekle
-        foreach ($includedItems as $itemId) {
-            $stmt = $pdo->prepare("INSERT INTO scope_selections (scope_id, item_id) VALUES (:scope_id, :item_id)");
-            $stmt->execute([
-                'scope_id' => $scopeId,
-                'item_id' => $itemId
-            ]);
-        }
-
-        echo "<script>alert('Kapsam başarıyla kaydedildi.'); window.location.href='kapsamlar.php';</script>";
-        exit;
-
-    } catch (PDOException $e) {
-        echo "Hata: " . $e->getMessage();
-    }
-}
+$title = 'Yeni Kapsam Oluştur';
+include 'header.php';
 ?>
-
-<h2>Yeni Kapsam Oluştur</h2>
-
-<form method="POST" action="">
-    <label for="scope_name">Kapsam Adı:</label>
-    <input type="text" name="scope_name" required><br><br>
-
-    <table border="1">
-        <tr>
-            <th>Kategori</th>
-            <th>İş Kalemi</th>
-            <th>Açıklama</th>
-            <th>Dahil Et</th>
-        </tr>
-
+<div class="row">
+    <div class="col-md-2 bg-light min-vh-100">
+        <?php include 'sidebar.php'; ?>
+    </div>
+    <div class="col-md-10 pt-3">
         <?php
-        $stmt = $pdo->query("SELECT items.id, items.name AS item_name, items.description AS default_description, categories.name AS category_name
-                              FROM items
-                              JOIN categories ON items.category_id = categories.id
-                              ORDER BY categories.name, items.name");
-        $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-        foreach ($items as $item):
+        if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+            $scopeName = $_POST['scope_name'];
+            $includedItems = $_POST['included_items'] ?? [];
+            $descriptions = $_POST['descriptions'] ?? [];
+            try {
+                $stmt = $pdo->prepare('INSERT INTO scopes (name) VALUES (:name)');
+                $stmt->execute(['name' => $scopeName]);
+                $scopeId = $pdo->lastInsertId();
+                foreach ($includedItems as $itemId) {
+                    $stmt = $pdo->prepare('INSERT INTO scope_selections (scope_id, item_id) VALUES (:scope_id, :item_id)');
+                    $stmt->execute(['scope_id' => $scopeId, 'item_id' => $itemId]);
+                }
+                echo "<script>alert('Kapsam başarıyla kaydedildi.'); window.location.href='index.php';</script>";
+                exit;
+            } catch (PDOException $e) {
+                echo 'Hata: ' . $e->getMessage();
+            }
+        }
         ?>
-            <tr>
-                <td><?= htmlspecialchars($item['category_name']) ?></td>
-                <td><input type="text" value="<?= htmlspecialchars($item['item_name']) ?>" readonly></td>
-                <td>
-                    <textarea name="descriptions[<?= $item['id'] ?>]" rows="2" cols="40"><?= htmlspecialchars($item['default_description']) ?></textarea>
-                </td>
-                <td><input type="checkbox" name="included_items[]" value="<?= $item['id'] ?>"></td>
-            </tr>
-        <?php endforeach; ?>
-    </table>
-
-    <br><button type="submit">Kaydet</button>
-</form>
-</body>
-</html>
+        <h2>Yeni Kapsam Oluştur</h2>
+        <form method="POST" action="" class="mb-3">
+            <div class="mb-3">
+                <label for="scope_name" class="form-label">Kapsam Adı:</label>
+                <input type="text" name="scope_name" id="scope_name" class="form-control" required>
+            </div>
+            <table class="table table-striped datatable" id="scope-items">
+                <thead>
+                    <tr>
+                        <th>Kategori</th>
+                        <th>İş Kalemi</th>
+                        <th>Açıklama</th>
+                        <th>Dahil Et</th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php
+                $stmt = $pdo->query("SELECT items.id, items.name AS item_name, items.description AS default_description, categories.name AS category_name FROM items JOIN categories ON items.category_id = categories.id ORDER BY categories.name, items.name");
+                $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                foreach ($items as $item):
+                ?>
+                    <tr>
+                        <td><?= htmlspecialchars($item['category_name']) ?></td>
+                        <td><input type="text" value="<?= htmlspecialchars($item['item_name']) ?>" readonly class="form-control-plaintext"></td>
+                        <td>
+                            <textarea name="descriptions[<?= $item['id'] ?>]" rows="2" cols="40" class="form-control"><?= htmlspecialchars($item['default_description']) ?></textarea>
+                        </td>
+                        <td class="text-center"><input type="checkbox" name="included_items[]" value="<?= $item['id'] ?>"></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+            <button type="submit" class="btn btn-success">Kaydet</button>
+        </form>
+    </div>
+</div>
+<?php include 'footer.php'; ?>

--- a/kapsamlar.php
+++ b/kapsamlar.php
@@ -1,31 +1,43 @@
 <?php
-// kapsamlar.php - tek dosyada kapsam listeleme, ekleme, silme işlemleri
-include "db.php";
-if ($_SERVER["REQUEST_METHOD"] === "POST") {
-    if (isset($_POST["kapsam_adi"])) {
-        $stmt = $pdo->prepare("INSERT INTO scopes (name) VALUES (?)");
-        $stmt->execute([$_POST["kapsam_adi"]]);
+// kapsamlar.php - kapsam listeleme, ekleme, silme
+include 'db.php';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['kapsam_adi'])) {
+        $stmt = $pdo->prepare('INSERT INTO scopes (name) VALUES (?)');
+        $stmt->execute([$_POST['kapsam_adi']]);
     }
-    if (isset($_POST["sil_id"])) {
-        $stmt = $pdo->prepare("DELETE FROM scopes WHERE id = ?");
-        $stmt->execute([$_POST["sil_id"]]);
+    if (isset($_POST['sil_id'])) {
+        $stmt = $pdo->prepare('DELETE FROM scopes WHERE id = ?');
+        $stmt->execute([$_POST['sil_id']]);
     }
 }
-$kapsamlar = $pdo->query("SELECT * FROM scopes")->fetchAll();
+$kapsamlar = $pdo->query('SELECT * FROM scopes')->fetchAll();
 ?>
-<!DOCTYPE html>
-<html>
-<head><title>Kapsamlar</title></head>
-<body>
 <h2>Kapsam Listesi</h2>
-<ul>
-<?php foreach ($kapsamlar as $kapsam): ?>
-<li><?= htmlspecialchars($kapsam['name']) ?>
-<form method="post" style="display:inline;"><input type="hidden" name="sil_id" value="<?= $kapsam['id'] ?>"><button>Sil</button></form>
-</li>
-<?php endforeach; ?>
-</ul>
+<table class="table datatable" id="kapsamlar-table">
+    <thead>
+        <tr><th>Kapsam Adı</th><th>Sil</th></tr>
+    </thead>
+    <tbody>
+    <?php foreach ($kapsamlar as $kapsam): ?>
+        <tr>
+            <td><?= htmlspecialchars($kapsam['name']) ?></td>
+            <td>
+                <form method="post" onsubmit="return confirm('Silinsin mi?');" class="d-inline">
+                    <input type="hidden" name="sil_id" value="<?= $kapsam['id'] ?>">
+                    <button class="btn btn-sm btn-danger">Sil</button>
+                </form>
+            </td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
 <h3>Yeni Kapsam Ekle</h3>
-<form method="post"><input name="kapsam_adi"><button>Ekle</button></form>
-</body>
-</html>
+<form method="post" class="row g-2 mb-3">
+    <div class="col-auto">
+        <input class="form-control" name="kapsam_adi" required>
+    </div>
+    <div class="col-auto">
+        <button class="btn btn-primary">Ekle</button>
+    </div>
+</form>

--- a/kategoriler.php
+++ b/kategoriler.php
@@ -1,31 +1,43 @@
 <?php
-// kategoriler.php - tek dosyada kategori listeleme, ekleme, silme işlemleri
-include "db.php";
-if ($_SERVER["REQUEST_METHOD"] === "POST") {
-    if (isset($_POST["kategori_adi"])) {
-        $stmt = $pdo->prepare("INSERT INTO categories (name) VALUES (?)");
-        $stmt->execute([$_POST["kategori_adi"]]);
+// kategoriler.php - kategori listeleme, ekleme, silme
+include 'db.php';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['kategori_adi'])) {
+        $stmt = $pdo->prepare('INSERT INTO categories (name) VALUES (?)');
+        $stmt->execute([$_POST['kategori_adi']]);
     }
-    if (isset($_POST["sil_id"])) {
-        $stmt = $pdo->prepare("DELETE FROM categories WHERE id = ?");
-        $stmt->execute([$_POST["sil_id"]]);
+    if (isset($_POST['sil_id'])) {
+        $stmt = $pdo->prepare('DELETE FROM categories WHERE id = ?');
+        $stmt->execute([$_POST['sil_id']]);
     }
 }
-$kategoriler = $pdo->query("SELECT * FROM categories")->fetchAll();
+$kategoriler = $pdo->query('SELECT * FROM categories')->fetchAll();
 ?>
-<!DOCTYPE html>
-<html>
-<head><title>Kategoriler</title></head>
-<body>
 <h2>Kategori Listesi</h2>
-<ul>
-<?php foreach ($kategoriler as $kategori): ?>
-<li><?= htmlspecialchars($kategori['name']) ?>
-<form method="post" style="display:inline;"><input type="hidden" name="sil_id" value="<?= $kategori['id'] ?>"><button>Sil</button></form>
-</li>
-<?php endforeach; ?>
-</ul>
+<table class="table datatable" id="kategoriler-table">
+    <thead>
+        <tr><th>Kategori</th><th>Sil</th></tr>
+    </thead>
+    <tbody>
+    <?php foreach ($kategoriler as $kategori): ?>
+        <tr>
+            <td><?= htmlspecialchars($kategori['name']) ?></td>
+            <td>
+                <form method="post" onsubmit="return confirm('Silinsin mi?');" class="d-inline">
+                    <input type="hidden" name="sil_id" value="<?= $kategori['id'] ?>">
+                    <button class="btn btn-sm btn-danger">Sil</button>
+                </form>
+            </td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
 <h3>Yeni Kategori Ekle</h3>
-<form method="post"><input name="kategori_adi"><button>Ekle</button></form>
-</body>
-</html>
+<form method="post" class="row g-2 mb-3">
+    <div class="col-auto">
+        <input class="form-control" name="kategori_adi" required>
+    </div>
+    <div class="col-auto">
+        <button class="btn btn-primary">Ekle</button>
+    </div>
+</form>

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,9 +1,6 @@
 <!-- sidebar.php -->
-<div style="margin-bottom: 20px;">
-    <strong>Menü</strong><br>
-    <ul>
-        <li><a href="index.php">Kapsamlar</a></li>
-        <li><a href="kategoriler.php">Kategoriler</a></li>
-        <li><a href="is_kalemleri.php">İş Kalemleri</a></li>
-    </ul>
+<div class="list-group mb-3">
+    <a class="list-group-item list-group-item-action" href="index.php?page=kapsamlar">Kapsamlar</a>
+    <a class="list-group-item list-group-item-action" href="index.php?page=kategoriler">Kategoriler</a>
+    <a class="list-group-item list-group-item-action" href="index.php?page=is_kalemleri">İş Kalemleri</a>
 </div>


### PR DESCRIPTION
## Summary
- create `header.php` and `footer.php` with Bootstrap and DataTables assets
- update `sidebar.php` links and add Bootstrap classes
- convert listing pages to tables and initialize DataTables
- provide a category dropdown for adding items
- replace inline styles in `index.php` and use shared layout
- style scope creation page with Bootstrap table

## Testing
- `php -l header.php`
- `php -l footer.php`
- `php -l sidebar.php`
- `php -l index.php`
- `php -l kapsamlar.php`
- `php -l kategoriler.php`
- `php -l is_kalemleri.php`
- `php -l kapsam_olustur.php`
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_687c2998e2b88330b76591eef9ba124b