### PR TITLE
Implement dynamic scope entry form

### DIFF
--- a/export_excel.php
+++ b/export_excel.php
@@ -9,10 +9,14 @@ use PhpOffice\PhpSpreadsheet\Style\Alignment;
 
 $scope_id = isset($_GET['scope_id']) ? intval($_GET['scope_id']) : 0;
 
-$stmt = $pdo->prepare("SELECT ss.*, c.name AS category_name, i.name AS item_name, i.description
+$stmt = $pdo->prepare("SELECT
+                           COALESCE(ss.category_name, c.name) AS category_name,
+                           COALESCE(ss.item_name, i.name) AS item_name,
+                           COALESCE(ss.description, i.description) AS description,
+                           ss.quantity
                        FROM scope_selections ss
-                       JOIN items i ON ss.item_id = i.id
-                       JOIN categories c ON i.category_id = c.id
+                       LEFT JOIN items i ON ss.item_id = i.id
+                       LEFT JOIN categories c ON i.category_id = c.id
                        WHERE ss.scope_id = :scope_id");
 $stmt->execute(['scope_id' => $scope_id]);
 $data = $stmt->fetchAll();

--- a/kapsam_olustur.php
+++ b/kapsam_olustur.php
@@ -11,19 +11,30 @@ include 'header.php';
         <?php
         if ($_SERVER['REQUEST_METHOD'] == 'POST') {
             $scopeName = $_POST['scope_name'];
-            $includedItems = $_POST['included_items'] ?? [];
-            $descriptions = $_POST['descriptions'] ?? [];
+            $rows = $_POST['rows'] ?? [];
             try {
+                $pdo->beginTransaction();
                 $stmt = $pdo->prepare('INSERT INTO scopes (name) VALUES (:name)');
                 $stmt->execute(['name' => $scopeName]);
                 $scopeId = $pdo->lastInsertId();
-                foreach ($includedItems as $itemId) {
-                    $stmt = $pdo->prepare('INSERT INTO scope_selections (scope_id, item_id) VALUES (:scope_id, :item_id)');
-                    $stmt->execute(['scope_id' => $scopeId, 'item_id' => $itemId]);
+
+                $insert = $pdo->prepare('INSERT INTO scope_selections (scope_id, item_id, category_name, item_name, description, included, quantity) VALUES (:scope_id, :item_id, :category_name, :item_name, :description, :included, :quantity)');
+                foreach ($rows as $row) {
+                    $insert->execute([
+                        'scope_id' => $scopeId,
+                        'item_id' => $row['item_id'] ?? 0,
+                        'category_name' => $row['category'] ?? '',
+                        'item_name' => $row['item_name'] ?? '',
+                        'description' => $row['description'] ?? '',
+                        'included' => isset($row['included']) ? (int)$row['included'] : 0,
+                        'quantity' => isset($row['quantity']) ? (int)$row['quantity'] : 0
+                    ]);
                 }
+                $pdo->commit();
                 echo "<script>alert('Kapsam başarıyla kaydedildi.'); window.location.href='index.php';</script>";
                 exit;
             } catch (PDOException $e) {
+                $pdo->rollBack();
                 echo 'Hata: ' . $e->getMessage();
             }
         }
@@ -34,34 +45,95 @@ include 'header.php';
                 <label for="scope_name" class="form-label">Kapsam Adı:</label>
                 <input type="text" name="scope_name" id="scope_name" class="form-control" required>
             </div>
-            <table class="table table-striped datatable" id="scope-items">
-                <thead>
-                    <tr>
-                        <th>Kategori</th>
-                        <th>İş Kalemi</th>
-                        <th>Açıklama</th>
-                        <th>Dahil Et</th>
-                    </tr>
-                </thead>
-                <tbody>
-                <?php
+            <table class="table table-striped" id="scope-items">
+    <thead>
+        <tr>
+            <th>Kategori</th>
+            <th>İş Kalemi</th>
+            <th>Açıklama</th>
+            <th>Adet</th>
+            <th>Dahil</th>
+            <th>Sil</th>
+        </tr>
+    </thead>
+    <tbody>
+<?php
                 $stmt = $pdo->query("SELECT items.id, items.name AS item_name, items.description AS default_description, categories.name AS category_name FROM items JOIN categories ON items.category_id = categories.id ORDER BY categories.name, items.name");
                 $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
-                foreach ($items as $item):
-                ?>
-                    <tr>
-                        <td><?= htmlspecialchars($item['category_name']) ?></td>
-                        <td><input type="text" value="<?= htmlspecialchars($item['item_name']) ?>" readonly class="form-control-plaintext"></td>
-                        <td>
-                            <textarea name="descriptions[<?= $item['id'] ?>]" rows="2" cols="40" class="form-control"><?= htmlspecialchars($item['default_description']) ?></textarea>
-                        </td>
-                        <td class="text-center"><input type="checkbox" name="included_items[]" value="<?= $item['id'] ?>"></td>
-                    </tr>
-                <?php endforeach; ?>
-                </tbody>
-            </table>
-            <button type="submit" class="btn btn-success">Kaydet</button>
+                foreach ($items as $index => $item):
+?>
+        <tr>
+            <td><input type="text" name="rows[<?= $index ?>][category]" class="form-control" value="<?= htmlspecialchars($item['category_name']) ?>"></td>
+            <td><input type="text" name="rows[<?= $index ?>][item_name]" class="form-control" value="<?= htmlspecialchars($item['item_name']) ?>"></td>
+            <td>
+                <textarea name="rows[<?= $index ?>][description]" rows="2" class="form-control"><?= htmlspecialchars($item['default_description']) ?></textarea>
+                <input type="hidden" name="rows[<?= $index ?>][item_id]" value="<?= $item['id'] ?>">
+            </td>
+            <td><input type="number" name="rows[<?= $index ?>][quantity]" class="form-control" value="0" min="0"></td>
+            <td class="text-center">
+                <input type="hidden" name="rows[<?= $index ?>][included]" value="0">
+                <input type="checkbox" name="rows[<?= $index ?>][included]" value="1">
+            </td>
+            <td><button type="button" class="btn btn-sm btn-danger delete-row">Sil</button></td>
+        </tr>
+<?php endforeach; ?>
+    </tbody>
+</table>
+<div class="row g-2 mb-3" id="add-row-form">
+    <div class="col-auto">
+        <select id="new-category" class="form-select">
+            <option value="">Kategori Seçin</option>
+<?php
+                        $cats = $pdo->query('SELECT name FROM categories ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+                        foreach ($cats as $cat): ?>
+            <option value="<?= htmlspecialchars($cat['name']) ?>"><?= htmlspecialchars($cat['name']) ?></option>
+<?php endforeach; ?>
+        </select>
+    </div>
+    <div class="col-auto">
+        <input id="new-item" class="form-control" placeholder="İş Kalemi">
+    </div>
+    <div class="col-auto">
+        <textarea id="new-description" class="form-control" rows="2" placeholder="Açıklama"></textarea>
+    </div>
+    <div class="col-auto">
+        <button type="button" id="add-row-btn" class="btn btn-primary">Satır Ekle</button>
+    </div>
+</div>
+
+        <button type="submit" class="btn btn-success">Kaydet</button>
         </form>
     </div>
 </div>
+<script>
+window.addEventListener('load', function(){
+    let rowIndex = <?php echo count($items); ?>;
+    $('#add-row-btn').on('click', function(){
+        const cat = $('#new-category').val();
+        const item = $('#new-item').val();
+        const desc = $('#new-description').val();
+        if(!cat || !item) return;
+        const escCat = $('<div>').text(cat).html();
+        const escItem = $('<div>').text(item).html();
+        const escDesc = $('<div>').text(desc).html();
+        let row = `<tr>
+            <td><input type="text" name="rows[${rowIndex}][category]" class="form-control" value="${escCat}"></td>
+            <td><input type="text" name="rows[${rowIndex}][item_name]" class="form-control" value="${escItem}"></td>
+            <td><textarea name="rows[${rowIndex}][description]" rows="2" class="form-control">${escDesc}</textarea><input type="hidden" name="rows[${rowIndex}][item_id]" value="0"></td>
+            <td><input type="number" name="rows[${rowIndex}][quantity]" class="form-control" value="0" min="0"></td>
+            <td class="text-center"><input type="hidden" name="rows[${rowIndex}][included]" value="0"><input type="checkbox" name="rows[${rowIndex}][included]" value="1" checked></td>
+            <td><button type="button" class="btn btn-sm btn-danger delete-row">Sil</button></td>
+        </tr>`;
+        $('#scope-items tbody').append(row);
+        $('#new-category').val('');
+        $('#new-item').val('');
+        $('#new-description').val('');
+        rowIndex++;
+    });
+
+    $(document).on('click', '.delete-row', function(){
+        $(this).closest('tr').remove();
+    });
+});
+</script>
 <?php include 'footer.php'; ?>

--- a/kapsamlar.php
+++ b/kapsamlar.php
@@ -63,12 +63,5 @@ $kapsamlar = $pdo->query('SELECT * FROM scopes')->fetchAll();
 </form>
 <?php else: ?>
 <h3>Yeni Kapsam Ekle</h3>
-<form method="post" class="row g-2 mb-3">
-    <div class="col-auto">
-        <input class="form-control" name="kapsam_adi" required>
-    </div>
-    <div class="col-auto">
-        <button class="btn btn-primary">Ekle</button>
-    </div>
-</form>
+<a href="?page=kapsam_olustur" class="btn btn-primary mb-3">Kapsam Oluştur</a>
 <?php endif; ?>

--- a/scope_db.sql
+++ b/scope_db.sql
@@ -133,6 +133,9 @@ CREATE TABLE `scope_selections` (
   `id` int(11) NOT NULL,
   `scope_id` int(11) NOT NULL,
   `item_id` int(11) NOT NULL,
+  `category_name` varchar(255) DEFAULT NULL,
+  `item_name` varchar(255) DEFAULT NULL,
+  `description` text DEFAULT NULL,
   `included` tinyint(1) NOT NULL DEFAULT 1,
   `quantity` int(11) DEFAULT 0,
   `created_at` timestamp NOT NULL DEFAULT current_timestamp()


### PR DESCRIPTION
## Summary
- extend `scope_selections` table with fields for custom item data
- update `kapsam_olustur.php` with editable table rows, add-row form and JS logic
- read custom values in `export_excel.php`
- link from scope list to new creation page

## Testing
- `php -l kapsam_olustur.php`
- `php -l export_excel.php`
- `php -l kapsamlar.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_687c30c7c7288330be15011df9f17199