### PR TITLE
Scope editing form updates

### DIFF
--- a/kapsamlar.php
+++ b/kapsamlar.php
@@ -1,28 +1,12 @@
 <?php
 // kapsamlar.php - kapsam listeleme, ekleme, silme
 include 'db.php';
-// POST işlemleri: ekle, güncelle, sil
+// POST işlemleri: sadece silme
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (isset($_POST['kapsam_adi'])) {
-        if (!empty($_POST['edit_id'])) {
-            $stmt = $pdo->prepare('UPDATE scopes SET name = ? WHERE id = ?');
-            $stmt->execute([$_POST['kapsam_adi'], $_POST['edit_id']]);
-        } else {
-            $stmt = $pdo->prepare('INSERT INTO scopes (name) VALUES (?)');
-            $stmt->execute([$_POST['kapsam_adi']]);
-        }
-    }
     if (isset($_POST['sil_id'])) {
         $stmt = $pdo->prepare('DELETE FROM scopes WHERE id = ?');
         $stmt->execute([$_POST['sil_id']]);
     }
-}
-
-$duzenleKapsam = null;
-if (isset($_GET['edit_id'])) {
-    $stmt = $pdo->prepare('SELECT * FROM scopes WHERE id = ?');
-    $stmt->execute([$_GET['edit_id']]);
-    $duzenleKapsam = $stmt->fetch();
 }
 
 $kapsamlar = $pdo->query('SELECT * FROM scopes')->fetchAll();
@@ -37,7 +21,7 @@ $kapsamlar = $pdo->query('SELECT * FROM scopes')->fetchAll();
         <tr>
             <td><?= htmlspecialchars($kapsam['name']) ?></td>
             <td>
-                <a href="?page=kapsamlar&edit_id=<?= $kapsam['id'] ?>" class="btn btn-sm btn-secondary">Düzenle</a>
+                <a href="?page=kapsam_olustur&id=<?= $kapsam['id'] ?>" class="btn btn-sm btn-secondary">Düzenle</a>
             </td>
             <td>
                 <form method="post" onsubmit="return confirm('Silinsin mi?');" class="d-inline">
@@ -49,19 +33,5 @@ $kapsamlar = $pdo->query('SELECT * FROM scopes')->fetchAll();
     <?php endforeach; ?>
     </tbody>
 </table>
-<?php if ($duzenleKapsam): ?>
-<h3>Kapsamı Düzenle</h3>
-<form method="post" class="row g-2 mb-3">
-    <div class="col-auto">
-        <input class="form-control" name="kapsam_adi" value="<?= htmlspecialchars($duzenleKapsam['name']) ?>" required>
-        <input type="hidden" name="edit_id" value="<?= $duzenleKapsam['id'] ?>">
-    </div>
-    <div class="col-auto">
-        <button class="btn btn-success">Güncelle</button>
-        <a href="?page=kapsamlar" class="btn btn-secondary">İptal</a>
-    </div>
-</form>
-<?php else: ?>
 <h3>Yeni Kapsam Ekle</h3>
 <a href="?page=kapsam_olustur" class="btn btn-primary mb-3">Kapsam Oluştur</a>
-<?php endif; ?>


### PR DESCRIPTION
## Summary
- allow editing scopes using the same form as creation
- remove quantity column from scope form

## Testing
- `php -l kapsam_olustur.php`
- `php -l kapsamlar.php`
- `php -l index.php`
- `php -l export_excel.php`
- `php -l kategoriler.php`
- `php -l is_kalemleri.php`
- `php -l admin_panel.php`


------
https://chatgpt.com/codex/tasks/task_e_687c3eef427083308bbf8235b9f842f0