### PR TITLE
Fix description field in scope form

### DIFF
--- a/kapsam_olustur.php
+++ b/kapsam_olustur.php
@@ -87,8 +87,8 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
             <td><input type="text" name="rows[<?= $index ?>][category]" class="form-control" value="<?= htmlspecialchars($item['category_name']) ?>"></td>
             <td><input type="text" name="rows[<?= $index ?>][item_name]" class="form-control" value="<?= htmlspecialchars($item['item_name']) ?>"></td>
             <td>
-                <textarea name="rows[<?= $index ?>][description]" rows="2" class="form-control"><?= htmlspecialchars($item['default_description']) ?></textarea>
-                <input type="hidden" name="rows[<?= $index ?>][item_id]" value="<?= $item['id'] ?>">
+                <textarea name="rows[<?= $index ?>][description]" rows="2" class="form-control"><?= htmlspecialchars($item['description']) ?></textarea>
+                <input type="hidden" name="rows[<?= $index ?>][item_id]" value="<?= $item['item_id'] ?>">
             </td>
             <td class="text-center">
                 <input type="hidden" name="rows[<?= $index ?>][included]" value="0">


### PR DESCRIPTION
## Summary
- fix `default_description` key to `description`
- ensure hidden item_id field uses correct key

## Testing
- `php -l kapsam_olustur.php`

------
https://chatgpt.com/codex/tasks/task_e_687c431157e08330978bf841f131ec49